### PR TITLE
Adapt skills to the official Blender MCP add-on

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -49,7 +49,7 @@ A Claude Code skill plugin that lets Claude use Blender like a senior 3D artist 
 
 ### Prerequisites
 
-1. **Blender ≥ 4.0** with the [BlenderMCP addon](https://github.com/ahujasid/blender-mcp) installed and running on port 9876.
+1. **Blender ≥ 4.0** with the official Blender MCP add-on (install from Blender's extensions platform, then enable it in Preferences → Add-ons) installed and enabled.
 2. **Claude Code** ≥ 1.0 with skills support.
 3. **Python 3.9+** with `opencv-python`, `numpy`, `scipy`, `Pillow` (only needed for `wireframe-to-3d` — install with `pip install -r ../requirements.txt`).
 
@@ -151,7 +151,7 @@ User: "Hero shot of a sword on a stone pedestal, exported as glTF"
 - **Pure-skill design**: no Python wrapper, no custom MCP. Claude is the orchestrator. Sub-skills are markdown decision trees + inline code recipes.
 - **Generated Python via `mcp__blender__execute_blender_code`**: each call is a fresh namespace. Objects identified by `bpy.data.objects['name']`, never by Python variables.
 - **Naming convention**: `GEO-`, `MAT-`, `LGT-`, `CAM-`, `ARM-`, `COL-` prefixes (Blender Studio standard).
-- **MCP transport**: `ahujasid/blender-mcp` socket on :9876 (synchronous, 180 s timeout per call).
+- **MCP transport**: official Blender MCP add-on (runs inside Blender; tools execute synchronously).
 
 See `../docs/` for full architecture notes, MCP coverage assessment, and verification report.
 
@@ -162,7 +162,7 @@ See `../docs/` for full architecture notes, MCP coverage assessment, and verific
 This plugin coexists peacefully with:
 
 - [`ra100/blender-claude-plugin`](https://github.com/ra100/blender-claude-plugin) — generalist Blender API reference skills (geometry nodes, shader nodes, compositor). Install both for the broadest coverage.
-- [`Dev-GOM/blender-toolkit`](https://mcpmarket.com/tools/skills/blender-toolkit) — specialty Mixamo retargeting via a separate WebSocket addon (port 9400+, different from ahujasid's :9876). Both can run simultaneously.
+- [`Dev-GOM/blender-toolkit`](https://mcpmarket.com/tools/skills/blender-toolkit) — specialty Mixamo retargeting via a separate WebSocket addon (separate WebSocket transport, independent of the official MCP add-on). Both can run simultaneously.
 
 ---
 
@@ -187,5 +187,5 @@ Open issues at: https://github.com/RobLe3/cc-blender-skill/issues
 Include:
 - Which skill triggered (or didn't)
 - Your Blender version
-- Your `ahujasid/blender-mcp` version
+- Your Blender MCP add-on version
 - The full prompt + Claude's response (or refusal)

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -8,7 +8,7 @@
   "requires": {
     "claude-code": ">=1.0.0",
     "blender": ">=4.0",
-    "blender-mcp": "ahujasid/blender-mcp >=1.5.0"
+    "blender-mcp": "official Blender MCP add-on (Blender extensions platform, lab_blender_org/mcp)"
   },
   "skills": [
     {

--- a/plugin/skills/animation-quality-gate/SKILL.md
+++ b/plugin/skills/animation-quality-gate/SKILL.md
@@ -2,7 +2,7 @@
 name: animation-quality-gate
 description: Validate Blender animation attempts before accepting them by rendering contact sheets, checking silhouette stability, flicker, framing, subject dominance, layer separation, export compatibility, and motion-design coherence. Use after animation renders or when the user says motion/morph/outside elements look bad.
 when_to_use: Animation QA, contact-sheet review, motion critique, morph validation, texture flicker detection, storyboard checks, rejecting bad animation passes, pre-export animation acceptance gates.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Animation Quality Gate

--- a/plugin/skills/atlas-uv-fitting/SKILL.md
+++ b/plugin/skills/atlas-uv-fitting/SKILL.md
@@ -2,7 +2,7 @@
 name: atlas-uv-fitting
 description: Detect texture-atlas regions and map each source part to its own UV rectangle or projected UV surface. Use when a texture pack must fit a Blender model 1:1, when textures look off/stretched, when alpha decals or lightmaps are provided, or before exporting a textured GLB for a brand mascot/logo.
 when_to_use: Texture atlas region detection, per-part UV mapping, front-projected UVs, decal/lightmap handling, texture validation against source templates.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_object_info
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Atlas UV Fitting

--- a/plugin/skills/blender-animation/SKILL.md
+++ b/plugin/skills/blender-animation/SKILL.md
@@ -2,7 +2,7 @@
 name: blender-animation
 description: Animate objects, cameras, lights, and properties in Blender — keyframes, F-curves, easing (Bezier, Linear, Sine, Bounce, Elastic), shape keys (morph targets / blendshapes / visemes), drivers (Python expressions on properties), NLA actions for reuse and layering. Use whenever the user asks to "animate this", "make it move / rotate / scale over time", "add keyframes", "loop / oscillate", "shape key / morph / blendshape", "visemes for lip sync", or any time-based property change. Make sure to use this skill even if the user does not say "animate" — also covers "spin it slowly", "make it wave", "fade in / out", "pulse", "facial expression".
 when_to_use: Any time-based animation, keyframe insertion, F-curve manipulation, shape-key editing, or driver setup in Blender.
-allowed-tools: Read Bash mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Blender Animation

--- a/plugin/skills/blender-cameras/SKILL.md
+++ b/plugin/skills/blender-cameras/SKILL.md
@@ -2,7 +2,7 @@
 name: blender-cameras
 description: Set up Blender cameras with cinematic intent — focal length, depth of field (f-stop / focus object), composition (rule of thirds, leading lines), animated cameras (orbit, dolly, push-in), tracking constraints. Use whenever the user asks to "set up the camera", "frame the shot", "make it look cinematic / hero / portrait / wide-angle / telephoto", "add depth of field", "orbit the camera", or any composition/framing request. Make sure to use this skill even if the user does not say "camera" — also covers "hero shot", "close-up", "from above", "shallow focus", "85mm portrait look".
 when_to_use: Any camera placement, framing, focal length, DoF, or animated camera setup in Blender.
-allowed-tools: Read Bash mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Blender Cameras

--- a/plugin/skills/blender-export/SKILL.md
+++ b/plugin/skills/blender-export/SKILL.md
@@ -2,7 +2,7 @@
 name: blender-export
 description: Export Blender scenes to glTF/GLB (web/AR), FBX (game engines), OBJ (universal), USD (VFX pipelines), STL (3D printing). Includes per-format settings, embed/unpack textures, axis conversion, polygon optimization (Decimate), and target-platform validation. Use whenever the user asks to "export this", "save as glTF / FBX / OBJ / STL / USD", "package for Unity / Unreal / Three.js / web / AR / 3D print", or any output format conversion. Make sure to use this skill even if the user does not say "export" — also covers "package this for the web", "make it work in Unity", "send to Unreal", "save for 3D printing".
 when_to_use: Any export to a non-.blend format, packaging for game engines, web, AR, or 3D printing.
-allowed-tools: Read Bash mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Blender Export

--- a/plugin/skills/blender-lighting/SKILL.md
+++ b/plugin/skills/blender-lighting/SKILL.md
@@ -2,7 +2,7 @@
 name: blender-lighting
 description: Light Blender scenes professionally — three-point setups, HDRI environments, studio/cinematic/dramatic configurations, light groups, color temperature, soft vs hard shadows. Use whenever the user asks to "light the scene", "set up lighting", "make it look cinematic / dramatic / studio / outdoor / sunset", "add a key light", "use HDRI", or any lighting-related request. Make sure to use this skill even if the user does not say "light" — also covers "make it look professional", "studio shot", "moody atmosphere", "golden hour", "rim light". Pairs with blender-materials (lighting reveals materials) and blender-cameras (lighting + composition together = shot).
 when_to_use: Any lighting setup or modification in Blender. Includes HDRI/environment lighting and individual lamp placement.
-allowed-tools: Read Bash mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Blender Lighting

--- a/plugin/skills/blender-materials/SKILL.md
+++ b/plugin/skills/blender-materials/SKILL.md
@@ -2,7 +2,7 @@
 name: blender-materials
 description: Create and assign PBR materials in Blender via Principled BSDF — metals, glass, plastic, fabric, skin, organics. Covers physically-based material recipes with real-world values, Coat layer (varnish/car paint), Sheen (cloth), Subsurface scattering (skin/wax), Transmission (glass), and procedural patterns (wood grain, marble, fabric weave). Use whenever the user asks to "make it look like X material", "give it a metallic finish", "apply a wood texture", "make this glass / plastic / brushed steel / leather / skin", or any look-development request. Make sure to use this skill even if the user does not say "material" — also covers "make it shiny", "matte finish", "looks like copper", "rough surface". Works with any geometry; pairs with blender-lighting (materials only look right under proper lighting).
 when_to_use: Any material assignment, PBR setup, shader work, or look-dev request in Blender.
-allowed-tools: Read Bash mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Blender Materials

--- a/plugin/skills/blender-modeling/SKILL.md
+++ b/plugin/skills/blender-modeling/SKILL.md
@@ -2,7 +2,7 @@
 name: blender-modeling
 description: Create and edit 3D meshes in Blender — primitives, hard-surface modeling, mesh operators, modifier stacks (Bevel, Subdivision, Boolean, Mirror, Array, Solidify), bmesh-level edits, retopology basics. Use whenever the user asks to "make/model/create/build a 3D object", "shape/sculpt this", "add a cube/sphere/cylinder/etc.", "extrude/inset/bevel this face", "add a modifier", or any geometry-creation request that isn't a wireframe trace. Make sure to use this skill even if the user does not say "model" — also covers "make a sword", "build a chair", "add a door", "carve out a hole". Pairs with blender-materials for look-dev and blender-pro-workflow for full pipelines.
 when_to_use: Any geometry creation, mesh edit, or modifier stack work in Blender. Not for wireframe → 3D conversion (use wireframe-to-3d) and not for sculpting strokes (Blender's sculpt mode is gestural, not text-driven).
-allowed-tools: Read Bash mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Blender Modeling

--- a/plugin/skills/blender-pro-workflow/SKILL.md
+++ b/plugin/skills/blender-pro-workflow/SKILL.md
@@ -2,7 +2,7 @@
 name: blender-pro-workflow
 description: End-to-end production workflow guidance for Blender — the order to assemble scenes (block-out → camera → light → forms → materials → detail → render → composite → export), critique protocols, time budgets, and recovery patterns. Use whenever the user asks to "make a complete scene / hero shot / production-quality render", "what's the right order to do this", "set up a full pipeline", or has a multi-step request crossing modeling + lighting + materials + rendering. Make sure to use this skill for any request that spans multiple phases of 3D work, even if the user does not say "workflow" — also covers "make a final image of X", "produce a hero render", "professional-looking result".
 when_to_use: Multi-phase Blender work spanning modeling + lighting + materials + render. Or when the user is unsure where to start. Often loaded BEFORE other sub-skills as a guide for sequencing.
-allowed-tools: Read Bash mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Blender Pro Workflow

--- a/plugin/skills/blender-rendering/SKILL.md
+++ b/plugin/skills/blender-rendering/SKILL.md
@@ -2,7 +2,7 @@
 name: blender-rendering
 description: Render Blender scenes with the right engine and settings — Cycles for photoreal, EEVEE for speed/stylized, sample counts, denoising (OptiX/OIDN), light path tuning, color management (AgX/Filmic), file output (PNG/EXR/MP4), animation rendering. Use whenever the user asks to "render this", "produce an image", "render a frame / animation", "make a final image", "save the render", or any output-generation request. Make sure to use this skill even if the user does not say "render" — also covers "make a picture", "save the result", "produce a final image", "export as image".
 when_to_use: Any image or animation render output request in Blender.
-allowed-tools: Read Bash mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Blender Rendering

--- a/plugin/skills/blender-skill-harmonizer/SKILL.md
+++ b/plugin/skills/blender-skill-harmonizer/SKILL.md
@@ -2,7 +2,7 @@
 name: blender-skill-harmonizer
 description: Harmonize multiple Blender skills into a coherent pipeline with clear activation precedence, handoff artifacts, dependency gates, and conflict-resolution rules. Use when a Blender task spans several skills, when reference-locked work conflicts with generic production workflow, after adding/updating skills, or when repeated failures indicate skill interference or missing inter/intra-play.
 when_to_use: Multi-skill Blender orchestration, skill graph audits, resolving overlaps between text-to-blender/pro-workflow/reference-to-3d/wireframe/UV/fit/repair skills, defining source-of-truth precedence, artifact contracts, and sequential-vs-parallel execution plans.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Blender Skill Harmonizer

--- a/plugin/skills/blender-uv-texturing/SKILL.md
+++ b/plugin/skills/blender-uv-texturing/SKILL.md
@@ -2,7 +2,7 @@
 name: blender-uv-texturing
 description: UV unwrap, atlas-map, project textures, use alpha decals, bake maps/lightmaps, and prepare texture-driven Blender assets for glTF/GLB export. Use whenever the user provides texture packs, texture atlases, decals, UV layouts, lightmaps, wants a texture to fit a mesh 1:1, or reports stretched/off textures. Pairs with reference-to-3d for template-accurate reconstruction and blender-materials for PBR values.
 when_to_use: Texture atlas/UV/baking/lightmap/decal work in Blender; any request involving texture fit, UV islands, project-from-view, texture packs, alpha decals, or baked maps.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Blender UV Texturing

--- a/plugin/skills/closed-surface-uv-coverage/SKILL.md
+++ b/plugin/skills/closed-surface-uv-coverage/SKILL.md
@@ -2,7 +2,7 @@
 name: closed-surface-uv-coverage
 description: Ensure textures and decals cover all visible surfaces of a closed or extruded Blender asset, especially front/back caps and sidewalls, instead of relying on partial projected planes, curves, or linework overlays. Use when back textures do not fill the model, side textures are missing, spin/turntable views expose plain sidewalls, or a model needs separate UV treatment for caps and side surfaces.
 when_to_use: Full surface texture coverage, sidewall UVs, back cap UVs, closed mesh UV coverage audits, texture fill validation, side/back turntable QA, replacing projected overlays with real surface materials.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_object_info mcp__blender__get_scene_info
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_object_detail_summary mcp__blender__get_objects_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Closed Surface UV Coverage

--- a/plugin/skills/contour-to-mesh/SKILL.md
+++ b/plugin/skills/contour-to-mesh/SKILL.md
@@ -2,7 +2,7 @@
 name: contour-to-mesh
 description: Build Blender mesh surfaces directly from extracted 2D contours/masks instead of approximate primitives. Use for 1:1 mascot/logo reconstruction, exact leaf/petal silhouettes, filled wireframe shapes, shallow bas-relief forms, or when the model outline must match a front template before adding depth.
 when_to_use: Source-locked contour-derived meshes, silhouette-first modeling, triangulated mask/contour surfaces, mesh generation from OpenCV contours, or replacing generic ellipses/primitives with measured shapes.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Contour to Mesh

--- a/plugin/skills/fit-repair-optimizer/SKILL.md
+++ b/plugin/skills/fit-repair-optimizer/SKILL.md
@@ -2,7 +2,7 @@
 name: fit-repair-optimizer
 description: Turn multiview fit reports into a sequential or parallel repair queue for aligning Blender products to source-of-truth templates. Use after validation shows disalignment, when the agent must iteratively fix wireframe, texture, lighting, or projection mismatches, and when skill gaps should trigger self-refinement before another rebuild.
 when_to_use: Iterative source-of-truth alignment repair, choosing sequential vs parallel correction order, generating fit repair queues, stopping on contradictory templates, or coordinating geometry/UV/lighting fixes from validation reports.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Fit Repair Optimizer

--- a/plugin/skills/landmark-fit-repair/SKILL.md
+++ b/plugin/skills/landmark-fit-repair/SKILL.md
@@ -2,7 +2,7 @@
 name: landmark-fit-repair
 description: Validate and repair source-locked Blender models using named landmarks such as leaf tips, shell corners, eyes, smile, rim thickness, aura center/radius, and view-specific depth markers. Use when bbox/IoU is insufficient and the model must align to templates at designed feature points.
 when_to_use: Landmark validation, feature-point deltas, control-point repair, face/eye/smile alignment, leaf tip alignment, aura ring fitting, iterative recipe parameter updates.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Landmark Fit Repair

--- a/plugin/skills/mascot-logo-reconstruction/SKILL.md
+++ b/plugin/skills/mascot-logo-reconstruction/SKILL.md
@@ -2,7 +2,7 @@
 name: mascot-logo-reconstruction
 description: Orchestrate a fail-gated, source-locked Blender reconstruction of mascots, logos, brand avatars, and stylized flat characters from wireframes, texture packs, and orthographic views. Use when the user requires a 1:1 brand/model match rather than a plausible stylized interpretation.
 when_to_use: Brand mascot/logo 3D reconstruction, exact part counts, texture-driven model matching, repeated “does not match reference” feedback, or full pipeline coordination across analysis, contour mesh, registration, UV fitting, validation, animation, and export.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Mascot / Logo Reconstruction

--- a/plugin/skills/multiview-fit-loop/SKILL.md
+++ b/plugin/skills/multiview-fit-loop/SKILL.md
@@ -2,7 +2,7 @@
 name: multiview-fit-loop
 description: Closed-loop compare-adjust-repeat workflow for fitting Blender models to supplied front/side/back/top templates and originals. Use when the user asks to compare the product to templates/originals and adjust until it fits across all dimensions, or when all views must pass measurable bbox/centroid/silhouette/edge validation before export.
 when_to_use: Multi-view validation and iterative fitting against reference templates, all-dimension mascot/object reconstruction, front/side/back/top overlay reports, fit deltas, automated adjustment loops.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Multiview Fit Loop

--- a/plugin/skills/orbital-hud-motion/SKILL.md
+++ b/plugin/skills/orbital-hud-motion/SKILL.md
@@ -2,7 +2,7 @@
 name: orbital-hud-motion
 description: Create tasteful circular/orbital HUD and aura animations around a Blender subject using source-derived arcs, dots, dashes, opacity, parallax, and restrained motion. Use when decorative circles, halos, orbit markers, scanner rings, or HUD effects must correlate with a logo/mascot rather than looking like random oversized rings.
 when_to_use: Animated circular HUD elements, aura rings, orbit arcs, dots, dashed circles, halo effects, mascot/logo motion graphics, source-derived decorative elements, avoiding bad outside-element animation.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Orbital HUD Motion

--- a/plugin/skills/orthographic-registration/SKILL.md
+++ b/plugin/skills/orthographic-registration/SKILL.md
@@ -2,7 +2,7 @@
 name: orthographic-registration
 description: Register front, side, back, and top orthographic reference views into a shared Blender coordinate contract. Use when a 3D model must match multi-view wireframes/templates, when side/back/top silhouettes are off, or before adding depth to a front-locked contour model.
 when_to_use: Multi-view mascot/object reconstruction, depth fitting from side/back/top views, orthographic blueprint alignment, reference planes/cameras with shared scale and centerline.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_scene_info
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Orthographic Registration

--- a/plugin/skills/quality-refinement-autoloop/SKILL.md
+++ b/plugin/skills/quality-refinement-autoloop/SKILL.md
@@ -2,7 +2,7 @@
 name: quality-refinement-autoloop
 description: Run a self-refinement loop when a Blender result is subpar, user expectations are not met, validation fails, or repeated issues reveal missing skill depth. The loop diagnoses the gap, decides whether to repair the artifact or acquire/refine a generic skill, sanitizes lessons for reusable publication, updates docs/versioning, validates, and prepares stage/commit/push when explicitly requested.
 when_to_use: Subpar output, user rejects quality, repeated Blender failure, RALPH loop, skill gap diagnosis, autonomous skill refinement, sanitized skill contribution, release prep, docs/version bump, staged commit and push workflow.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Quality Refinement Autoloop

--- a/plugin/skills/reference-analysis-validator/SKILL.md
+++ b/plugin/skills/reference-analysis-validator/SKILL.md
@@ -2,7 +2,7 @@
 name: reference-analysis-validator
 description: Measure and validate supplied reference images, wireframes, texture atlases, and Blender renders before declaring a reconstruction 1:1. Use when an asset must match a template, when visual feedback says the output is off, when part counts must be exact, or before exporting a brand mascot/logo reconstruction. Pairs with reference-to-3d, contour-to-mesh, orthographic-registration, atlas-uv-fitting, and Blender MCP.
 when_to_use: Any 1:1 reference/model validation task involving masks, overlays, part counts, centroids, bounding boxes, SSIM/IoU, source manifests, or fail-before-export gates.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Reference Analysis Validator

--- a/plugin/skills/reference-look-calibration/SKILL.md
+++ b/plugin/skills/reference-look-calibration/SKILL.md
@@ -2,7 +2,7 @@
 name: reference-look-calibration
 description: Calibrate Blender materials, lighting, camera crop, emission/glow, color management, and aura/HUD styling against supplied original/reference images using measurable color, brightness, saturation, bbox, and mask statistics. Use when a product must match the lighting/look of a source image or when audits say the product is too bright, desaturated, wrong hue, wrong glow, or wrong silhouette extent.
 when_to_use: Reference-based look-dev, lighting/material/color calibration, original-image visual matching, glow/aura/HUD matching, HSV/brightness/mask fit reports, final look pass after geometry and UV are locked.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Reference Look Calibration

--- a/plugin/skills/reference-to-3d/SKILL.md
+++ b/plugin/skills/reference-to-3d/SKILL.md
@@ -2,7 +2,7 @@
 name: reference-to-3d
 description: Reconstruct Blender models from supplied reference sheets, branding templates, texture atlases, orthographic front/side/back/top views, or mascot/logo art where visual fidelity to the source is more important than a plausible generated object. Use when the user says the model must match a template, wireframe, texture pack, character sheet, mascot sheet, or brand asset exactly; also use after feedback like "does not look like the reference", "fit the texture 1:1", "wrong number of visible parts", or "compare against the template". Requires Blender MCP plus local Python with Pillow/OpenCV/numpy; pairs with blender-uv-texturing, wireframe-to-3d, blender-modeling, blender-materials, and blender-export.
 when_to_use: User supplies reference images/templates/texture atlases/orthographic views and wants a model matching them, or repeated visual mismatch feedback requires a reference-locked corrective loop.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info mcp__blender__get_viewport_screenshot
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__get_screenshot_of_area_as_image mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Reference-to-3D Reconstruction

--- a/plugin/skills/text-to-blender/SKILL.md
+++ b/plugin/skills/text-to-blender/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: text-to-blender
-description: Drive Blender from natural language. Converts plain-English requests ("model a sword and render it with cinematic lighting", "make this glass look frosted", "set up three-point lighting", "export this scene as glTF for the web") into Blender Python code executed via the Blender MCP server. Acts as the orchestrator that picks and chain-loads specialised sub-skills (blender-modeling, blender-materials, blender-lighting, blender-cameras, blender-rendering, blender-animation, blender-export, wireframe-to-3d, blender-pro-workflow, blender-skill-harmonizer, quality-refinement-autoloop). Use this skill whenever the user wants Claude to do anything in Blender, including creating geometry, applying materials, lighting a scene, framing a camera, rendering, animating, or exporting. Make sure to invoke this skill even if the user does not say "Blender" — also covers requests like "create a 3D model of...", "render this...", "make a glTF from...", "set up a scene with...", or any 3D-creation task. Requires the Blender MCP addon (ahujasid/blender-mcp) running on port 9876.
+description: Drive Blender from natural language. Converts plain-English requests ("model a sword and render it with cinematic lighting", "make this glass look frosted", "set up three-point lighting", "export this scene as glTF for the web") into Blender Python code executed via the Blender MCP server. Acts as the orchestrator that picks and chain-loads specialised sub-skills (blender-modeling, blender-materials, blender-lighting, blender-cameras, blender-rendering, blender-animation, blender-export, wireframe-to-3d, blender-pro-workflow, blender-skill-harmonizer, quality-refinement-autoloop). Use this skill whenever the user wants Claude to do anything in Blender, including creating geometry, applying materials, lighting a scene, framing a camera, rendering, animating, or exporting. Make sure to invoke this skill even if the user does not say "Blender" — also covers requests like "create a 3D model of...", "render this...", "make a glTF from...", "set up a scene with...", or any 3D-creation task. Requires the official Blender MCP add-on enabled in Blender.
 when_to_use: User asks for any 3D creation, modification, lighting, rendering, animation, or export task. Anything involving Blender or that should reasonably be done in Blender.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info mcp__blender__get_viewport_screenshot
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__get_screenshot_of_area_as_image mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Text-to-Blender Orchestrator
 
 Turn plain-English requests into Blender work. You are the conductor: read the request, decide which sub-skills to chain-load, sequence them in the right order, and execute via the Blender MCP.
+
+> **MCP flavour note**: this plugin targets the **official Blender MCP add-on** (Blender extensions platform, `lab_blender_org/mcp`), not `ahujasid/blender-mcp`. Tool names, return conventions (`result` dict), screenshot/render parameters, and unavailable asset-download tools are documented in `references/official-blender-mcp.md` — read it before debugging any MCP tool mismatch. For final-quality visual validation prefer `render_viewport_to_path` over viewport screenshots.
 
 ## Multi-skill harmonization
 
@@ -26,7 +28,7 @@ The user speaks in tasks ("render a hero shot of a sword on a stone"); you:
 5. **Route to sub-skills** → load the relevant ones via `Read` and follow their instructions.
 6. **Sequence** the work in the order pros use (see `references/assembly-order.md`).
 7. **Execute** generated Python via `mcp__blender__execute_blender_code`.
-8. **Validate** with `mcp__blender__get_scene_info`, `get_object_info`, AND **`get_viewport_screenshot`** — see *Visual validation checkpoint* below. Numerical validation alone is not enough: the API can report success while geometry is grossly wrong.
+8. **Validate** with `mcp__blender__get_objects_summary`, `get_object_detail_summary`, AND **`get_screenshot_of_area_as_image`** — see *Visual validation checkpoint* below. Numerical validation alone is not enough: the API can report success while geometry is grossly wrong.
 9. **Iterate** — if the visual check shows an obvious problem (subject barely visible, wrong proportions, wrong orientation), fix and re-render BEFORE reporting success.
 10. **Report** to the user with concrete numbers AND a path to the proof render they can inspect.
 
@@ -54,7 +56,7 @@ If the user wants HDRI lighting, override this AFTER it runs (load the actual `.
 
 After rendering, **always**:
 
-1. Call `mcp__blender__get_viewport_screenshot` (or read the rendered file with `Read`).
+1. Render to a file with `mcp__blender__render_viewport_to_path` and read it with `Read` (or, for a quick viewport-shading check, call `mcp__blender__get_screenshot_of_area_as_image` with `area_ui_type="VIEW_3D"`).
 2. Visually verify against the user's request. Specifically:
    - Subject is visible and recognisable (not a thin streak, not magenta-flooded, not entirely in shadow)
    - Proportions match the real-world reference dimensions for that subject
@@ -98,12 +100,12 @@ The full reference list lives in `references/common-object-dimensions.md`. Do no
 
 Before any work, verify:
 
-1. **Blender MCP is reachable**. Call `mcp__blender__get_scene_info`. If it errors with "Could not connect to Blender":
-   > "Blender's MCP addon isn't running. Start Blender, enable the BlenderMCP addon (port 9876 default), then re-run."
+1. **Blender MCP is reachable**. Call `mcp__blender__get_objects_summary`. If it errors with "Could not connect to Blender":
+   > "Blender's MCP addon isn't running. Start Blender, enable the official Blender MCP add-on (Preferences → Add-ons → MCP), then re-run."
    
    Stop and ask the user to fix this.
 
-2. **Scene state**. `get_scene_info` returns the current objects. Decide:
+2. **Scene state**. `get_objects_summary` returns the current objects. Decide:
    - **Empty scene?** → Start fresh; build from primitives.
    - **Existing objects?** → Operate on them; do NOT delete unless asked.
    - **Default cube only?** → Probably safe to delete (`bpy.ops.object.delete()`).
@@ -196,7 +198,7 @@ Suffix `.L` / `.R` for left/right. Examples: `GEO-sword_blade`, `MAT-steel_brush
 
 ## Validation rule of thumb
 
-After significant work, call `mcp__blender__get_scene_info` and verify:
+After significant work, call `mcp__blender__get_objects_summary` and verify:
 - Expected objects exist with correct names.
 - Object counts make sense (no runaway duplication).
 - Polycount roughly matches target.
@@ -241,7 +243,7 @@ Example:
 | User reports "scene is grey / no materials visible" while looking at Blender's viewport | Blender viewport defaults to **Solid** shading mode which ignores materials. The render is correct; only the viewport looks grey. After every scene assembly, set viewport to Material Preview: `space.shading.type = 'MATERIAL'; space.shading.use_scene_lights = True; space.shading.use_scene_world = True` |
 | User reports "materials look flat / no texture" | Flat PBR colors lack surface variation. Add procedural textures (Noise/Voronoi → ColorRamp → Roughness or Bump) for steel scratches, hammered metal, leather grain, etc. See `blender-materials` Recipe 12 (procedural wood) for the pattern. |
 | Subject looks wrongly proportioned (e.g. blade too short, chair too narrow) | The orchestrator skipped the dimension lookup. Always read `references/common-object-dimensions.md` BEFORE generating modeling code. Don't guess. |
-| User asks for a "human" / "character" / "face" / "person" | Pure-recipe primitives produce a recognisable silhouette only, NOT a human face. Suggest one of: (a) `mcp__blender__download_polyhaven_asset` / `download_sketchfab_model` / `generate_hyper3d_model_via_text` for an actual human base mesh, then chain materials + lighting + render; (b) commission a Blender character artist (see `prompts/04-blender-workflow.md`). Do NOT pretend a sphere-with-features looks human — it doesn't. See `references/common-object-dimensions.md` "Characters / avatars" section. |
+| User asks for a "human" / "character" / "face" / "person" | Pure-recipe primitives produce a recognisable silhouette only, NOT a human face. Suggest one of: (a) a manually downloaded base mesh (Poly Haven / Sketchfab / a text-to-3D service; official MCP has no asset-download tools) for an actual human base mesh, then chain materials + lighting + render; (b) commission a Blender character artist (see `prompts/04-blender-workflow.md`). Do NOT pretend a sphere-with-features looks human — it doesn't. See `references/common-object-dimensions.md` "Characters / avatars" section. |
 | Elongated subject renders as a thin pole instead of a recognisable shape | Camera viewing the **thin axis** of an elongated object. Rotate the object so its broad axis faces the camera. See `blender-modeling` "Critical: axis orientation for elongated objects". |
 | Blade/spike has a "chiseled flat" tip instead of a point | Top vertices were scaled toward zero but not merged. Use the proper tapering recipe in `blender-modeling` ("Critical: tapering to a point") — collapse top verts to centerline AND `remove_doubles`. |
 | Coloured glass renders flat/metallic instead of "glass-like" | Tint set on `Base Color` of Principled BSDF only. Real coloured glass needs **Volume Absorption** for depth-based tint. See `blender-materials` Recipe 6b. Also: `Roughness=0.0` produces mirror-flat highlights that look metallic — use 0.02–0.05 instead. |

--- a/plugin/skills/text-to-blender/references/common-object-dimensions.md
+++ b/plugin/skills/text-to-blender/references/common-object-dimensions.md
@@ -52,9 +52,9 @@ The hard limit: a real human face requires **subtractive sculpting** (eye socket
 **Three realistic paths past this limit, all out of pure-recipe scope**:
 
 1. **Import an existing human base mesh** via the Blender MCP's other tools:
-   - `mcp__blender__download_polyhaven_asset` — Poly Haven has CC0 character assets
-   - `mcp__blender__download_sketchfab_model` — Sketchfab CC-BY models
-   - `mcp__blender__generate_hyper3d_model_via_text` — text-to-3D AI generation
+   - Download CC0 assets from Poly Haven (polyhaven.com) manually, then import (`bpy.ops.wm.obj_import`, glTF import) — the official MCP has no download tools
+   - Sketchfab CC-BY models — download manually, import as glTF/FBX
+   - Text-to-3D services (Hyper3D/Rodin, Meshy…) — generate on the web, import the resulting GLB
    These produce a real human mesh foundation that the orchestrator can then materially / lighting / pose via existing skills.
 
 2. **Sculpt mode** — gestural, not driven well from natural-language. The skill can prepare a base mesh and recommend the user sculpts manually.

--- a/plugin/skills/text-to-blender/references/official-blender-mcp.md
+++ b/plugin/skills/text-to-blender/references/official-blender-mcp.md
@@ -1,0 +1,66 @@
+# Official Blender MCP Add-on — Adapter Notes
+
+This plugin was originally written against `ahujasid/blender-mcp` (community
+socket addon on port 9876). This install has been adapted for the **official
+Blender MCP add-on** (Blender extensions platform, `lab_blender_org/mcp`,
+Blender ≥ 4.5/5.x). Read this when a tool name or return value doesn't behave
+as a skill describes.
+
+## Tool mapping (what the skills now reference)
+
+| Old (ahujasid) | Official add-on | Notes |
+|---|---|---|
+| `execute_blender_code(code)` | `execute_blender_code(code)` | Same name. Official version: assign a JSON-serialisable dict to a variable named `result` to return structured data. `print()` stdout is also captured (returned in a `stdout` field), but `result` is more reliable than parsing prints. |
+| `get_scene_info` | `get_objects_summary` | Returns collection hierarchy + objects (name, type, parent, visibility, selection). No parameters. |
+| `get_object_info(name)` | `get_object_detail_summary(name)` | Transforms, parent/children, modifiers, constraints, materials, collections. For bounding boxes / vertex counts, use `execute_blender_code` instead. |
+| `get_viewport_screenshot` | `get_screenshot_of_area_as_image(area_ui_type="VIEW_3D")` | Requires the area type argument. Returns PNG image content directly. |
+| — (no equivalent) | `render_viewport_to_path(output_path)` | Full render with current settings, saved to disk. **Prefer this for visual validation of final quality** (lighting/materials render correctly; viewport screenshots show viewport shading only). Read the saved file afterwards to inspect it. |
+| — | `render_thumbnail_to_path` | Quick small render. |
+| — | `search_api_docs(query)` / `search_manual_docs(query)` / `get_python_api_docs(path)` | Bundled Blender API + manual search. Use when unsure about an operator signature instead of guessing. |
+| — | `get_blendfile_summary_datablocks` etc. | Datablock statistics, linked libraries, missing files. |
+| `download_polyhaven_asset` | **not available** | Download from polyhaven.com manually (curl/browser), then import via `bpy.ops.wm.obj_import` / glTF import. |
+| `download_sketchfab_model` | **not available** | Same — manual download + import. |
+| `generate_hyper3d_model_via_text` | **not available** | Use a web text-to-3D service, import the GLB. |
+
+Tool name prefixes depend on the client: Claude Code exposes them as
+`mcp__<server>__<tool>` (e.g. `mcp__blender__get_objects_summary` if the server
+is registered as `blender`); Cursor exposes them via its MCP tool call with
+server + tool name. The skills use the `mcp__blender__…` spelling — map to your
+client's convention.
+
+## Returning data from `execute_blender_code`
+
+Preferred pattern (official add-on):
+
+```python
+import bpy
+# ... do work ...
+result = {"objects": [o.name for o in bpy.data.objects], "ok": True}
+```
+
+The dict in `result` comes back as structured JSON. Exceptions come back as
+tracebacks in an error status — no need to wrap everything in try/except.
+
+## Visual validation loop (adapted)
+
+1. `render_viewport_to_path("/tmp/check.png")` — real render, honest materials.
+2. Read `/tmp/check.png` and inspect.
+3. For quick orientation checks (is the object roughly there?), the cheaper
+   `get_screenshot_of_area_as_image(area_ui_type="VIEW_3D")` is fine.
+
+## Blender 5.x API gotchas (verified live on 5.1)
+
+- `scene.render.engine` is `'BLENDER_EEVEE'` again (not `BLENDER_EEVEE_NEXT`).
+- Compositor: `scene.node_tree` is gone → create a node group
+  (`bpy.data.node_groups.new(name, 'CompositorNodeTree')`), assign to
+  `scene.compositing_node_group`, add `NodeGroupOutput` + an OUTPUT interface
+  socket. Glare node options are now **input sockets**
+  (`glare.inputs['Type'].default_value = 'Bloom'`).
+- Actions are layered: iterate F-curves via
+  `action.layers[].strips[].channelbags[].fcurves`, not `action.fcurves`.
+- Video export: set `image_settings.media_type = 'VIDEO'` **before**
+  `file_format = 'FFMPEG'`.
+- In-place bmesh edits sometimes leave the depsgraph stale (render shows old
+  geometry). Reliable fix: swap the datablock —
+  `new = me.copy(); obj.data = new; bpy.data.meshes.remove(me)`.
+- More details: `references/blender-version-compat.md`.

--- a/plugin/skills/texture-driven-mesh-fitting/SKILL.md
+++ b/plugin/skills/texture-driven-mesh-fitting/SKILL.md
@@ -2,7 +2,7 @@
 name: texture-driven-mesh-fitting
 description: Reshape source-locked mesh boundaries so the geometry fits texture-atlas or decal contours 1:1 before final UV/material work. Use when textures look off because the model behind them does not match the source texture region, or when the mesh must adapt to the texture instead of stretching the texture onto an approximate mesh.
 when_to_use: Texture-driven geometry fitting, mesh boundary fitting to atlas masks, UV-preserving contour correspondence, point/landmark deformation, source mask to mesh repair.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_object_info
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Texture-Driven Mesh Fitting

--- a/plugin/skills/texture-state-animation/SKILL.md
+++ b/plugin/skills/texture-state-animation/SKILL.md
@@ -2,7 +2,7 @@
 name: texture-state-animation
 description: Design and validate texture-state transitions for Blender animations without ugly whole-image crossfades, texture popping, misregistered morphs, or target-engine-incompatible Python-only swaps. Use when animating between multiple source textures, mascot/logo states, style states, lightmaps, decals, or UI skins.
 when_to_use: Texture state animation, texture morphs, material state transitions, image sequence planning, masked wipes, glow reveals, texture registration, avoiding bad crossfades, GLB-compatible texture animation planning.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Texture State Animation

--- a/plugin/skills/wireframe-to-3d/SKILL.md
+++ b/plugin/skills/wireframe-to-3d/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: wireframe-to-3d
-description: Convert 2D orthographic wireframe PNG drawings to 3D Blender models exported as glTF/GLB. Use this skill whenever the user provides wireframe images (technical drawings, line drawings, orthographic views, side/front/back panels) and wants to generate a 3D model, mesh, or .glb file. Triggers on phrases like "convert this wireframe to 3D", "make a 3D model from these drawings", "build a model from this wireframe", "generate GLB from these views", or any image-to-3D-mesh request involving line drawings. Make sure to use this skill even if the user does not explicitly say "wireframe" — also covers "orthographic views", "technical drawings", "line drawings of objects", "front and side views". Requires the Blender MCP addon to be running (port 9876) and Python with opencv-python, numpy, scipy installed.
+description: Convert 2D orthographic wireframe PNG drawings to 3D Blender models exported as glTF/GLB. Use this skill whenever the user provides wireframe images (technical drawings, line drawings, orthographic views, side/front/back panels) and wants to generate a 3D model, mesh, or .glb file. Triggers on phrases like "convert this wireframe to 3D", "make a 3D model from these drawings", "build a model from this wireframe", "generate GLB from these views", or any image-to-3D-mesh request involving line drawings. Make sure to use this skill even if the user does not explicitly say "wireframe" — also covers "orthographic views", "technical drawings", "line drawings of objects", "front and side views". Requires the official Blender MCP add-on to be enabled in Blender and Python with opencv-python, numpy, scipy installed.
 when_to_use: User provides one or more PNG wireframe images and wants a 3D model. Also use when user asks to model an object from front/side/back drawings, or to convert technical line art to glTF/GLB.
-allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_scene_info mcp__blender__get_object_info mcp__blender__get_viewport_screenshot
+allowed-tools: Read Bash Glob Grep mcp__blender__execute_blender_code mcp__blender__get_objects_summary mcp__blender__get_object_detail_summary mcp__blender__get_screenshot_of_area_as_image mcp__blender__render_viewport_to_path mcp__blender__search_api_docs
 ---
 
 # Wireframe-to-3D Conversion
@@ -23,8 +23,8 @@ You (Claude) are the orchestrator. The `scripts/` directory contains the only st
 
 Before any wireframe work, verify the environment:
 
-1. **Blender MCP is reachable**. Call `mcp__blender__get_scene_info`. If it errors with "Could not connect to Blender", stop and tell the user:
-   > "Blender's MCP addon isn't running. Start Blender, enable the BlenderMCP addon (port 9876), then re-run."
+1. **Blender MCP is reachable**. Call `mcp__blender__get_objects_summary`. If it errors with "Could not connect to Blender", stop and tell the user:
+   > "Blender's MCP addon isn't running. Start Blender, enable the official Blender MCP add-on (Preferences → Add-ons → MCP), then re-run."
 
 2. **Python deps for the analyzer**. Run:
    ```
@@ -210,9 +210,9 @@ If `size_mb > 15`: apply Decimate and re-export (see error recovery).
 
 After the full pipeline, validate before declaring success:
 
-1. `mcp__blender__get_scene_info` — confirm expected objects exist.
-2. For paired parts (left/right lens), call `mcp__blender__get_object_info` on each and compare bounding box widths. Tolerance: 1 mm.
-3. Triangle count: get via `get_object_info`. If a part exceeds budget, plan Decimate.
+1. `mcp__blender__get_objects_summary` — confirm expected objects exist.
+2. For paired parts (left/right lens), call `mcp__blender__get_object_detail_summary` on each and compare bounding box widths. Tolerance: 1 mm.
+3. Triangle count: get via `get_object_detail_summary`. If a part exceeds budget, plan Decimate.
 4. File size: must be ≤ 15 MB hard cap, ideally ≤ 8 MB.
 
 ## Error recovery


### PR DESCRIPTION
## Summary

I run this skill pack against the **official Blender MCP add-on** (the one shipped on the Blender extensions platform, `lab_blender_org/mcp`, bundled docs + tools) rather than `ahujasid/blender-mcp`, and adapted the skills so they work out of the box there. Sharing it back in case it is useful upstream.

- Tool name mapping across all 30 skills (`SKILL.md` frontmatter `allowed-tools` + body text):
  - `get_scene_info` → `get_objects_summary`
  - `get_object_info` → `get_object_detail_summary`
  - `get_viewport_screenshot` → `get_screenshot_of_area_as_image` (requires `area_ui_type="VIEW_3D"`)
  - added `render_viewport_to_path` (render-based visual validation) and `search_api_docs` (bundled API doc search) to `allowed-tools`
- Removed the port-9876 socket prerequisite from install/usage instructions (the official add-on runs inside Blender, no separate socket setup).
- Marked `download_polyhaven_asset` / `download_sketchfab_model` / `generate_hyper3d_model_via_text` as unavailable on the official add-on, with manual download-and-import alternatives in `common-object-dimensions.md`.
- Updated `plugin/manifest.json` dependency string.
- New reference: `text-to-blender/references/official-blender-mcp.md` with the full mapping table, the `result`-dict return convention of the official `execute_blender_code`, a render-based visual validation loop, and Blender 5.x API gotchas I hit live on 5.1.2 (compositor moved to `scene.compositing_node_group`, Glare options became input sockets, layered action F-curve access via `layers[].strips[].channelbags[]`, `media_type = 'VIDEO'` before `FFMPEG`, and depsgraph staleness after in-place bmesh edits — datablock swap fixes it).

## Test plan

- [x] Verified live against Blender 5.1.2 with the official MCP add-on: `execute_blender_code`, `get_objects_summary`, `get_object_detail_summary`, and `render_viewport_to_path` all round-trip (built and rendered a full stylized vehicle scene with animation through these skills' recipes).
- [x] `rg` audit: no stale `get_scene_info` / `get_object_info` / `get_viewport_screenshot` / `9876` references outside the adapter doc's mapping table.
- [ ] Re-run the trigger evals (`evals/evals.json`) — descriptions were left untouched, so trigger behaviour should be unchanged.

If you'd rather keep `ahujasid/blender-mcp` as the primary target, I'm happy to rework this as a parallel "official MCP" variant of the docs (e.g. keep both tool-name columns) instead of a replacement.
