### PR TITLE
blender-export: Unreal collision meshes (UCX_) and the Multires bake route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to **cc-blender-skill** since first commit. Detailed rationale per version is in [`VERSIONING.md`](./VERSIONING.md). Patch-by-patch root-cause notes are in [`docs/process/IMPLEMENTATION_LOG.md`](./docs/process/IMPLEMENTATION_LOG.md). Test results are in [`docs/test-results/`](./docs/test-results/).
 
 
+## [Unreleased]
+
+### Added
+
+- `blender-export` Recipe 9: Unreal collision meshes — the `UCX_`/`UBX_`/`USP_`/`UCP_`
+  naming convention, and a convexity check, because Unreal accepts a concave `UCX_`
+  hull silently and then behaves wrongly.
+- `blender-export` Recipe 10: baking a Multires sculpt to a normal map and exporting
+  the base cage, with the two failure modes that mislead — Multires must be last in
+  the modifier stack, and the modifier's viewport `levels` (not `total_levels`) is
+  what `use_mesh_modifiers` exports.
+- Four rows in the `blender-export` pitfalls table covering the above plus the
+  "No smoothing group information was found" warning.
+
+### Notes
+
+- Verified on Blender 5.2.1 LTS only. Nothing here was confirmed inside Unreal
+  itself; the collision and smoothing claims are conventions and Blender-side
+  behaviour, not engine-side test results.
+
 ## [1.3.0] — 2026-05-01
 
 ### Added

--- a/plugin/skills/blender-export/SKILL.md
+++ b/plugin/skills/blender-export/SKILL.md
@@ -215,6 +215,88 @@ else:
 
 Always verify after export. Use `Bash` tool: `ls -la /tmp/output.glb`.
 
+### Recipe 9 — Collision meshes for Unreal (`UCX_`)
+
+Unreal reads collision out of the FBX **by object name**. A collider is a
+separate object in the same file, named for the mesh it wraps:
+
+| Prefix | Shape |
+|--------|-------|
+| `UCX_` | Convex hull — the usual choice |
+| `UBX_` | Box |
+| `USP_` | Sphere |
+| `UCP_` | Capsule |
+
+`SM_Chair` gets `UCX_SM_Chair_01`, `UCX_SM_Chair_02`, ... Select the mesh and
+its colliders together and export with `use_selection=True`; they must travel
+in one file.
+
+**A concave `UCX_` hull is accepted silently** — no warning, no import error,
+and wrong collision in engine. Check before exporting:
+
+```python
+import bpy
+
+def is_convex(obj, tolerance=1e-5):
+    """True when every vertex sits behind every face plane."""
+    coords = [v.co for v in obj.data.vertices]
+    for poly in obj.data.polygons:
+        if poly.normal.length_squared < 1e-12:
+            continue
+        for co in coords:
+            if (co - poly.center).dot(poly.normal) > tolerance:
+                return False
+    return True
+
+for obj in bpy.data.objects:
+    if obj.name.startswith(('UCX_', 'UBX_', 'USP_', 'UCP_')):
+        print(f"collision:{obj.name} convex:{is_convex(obj)}")
+```
+
+Derive hull dimensions from the mesh bounding box rather than typing them —
+hand-entered collider positions drift from the geometry and nothing checks it.
+
+Prefer several primitive hulls over one dense hull. A single hull around a
+table is a solid block with no space under it.
+
+### Recipe 10 — Sculpted detail: bake it, do not export it
+
+A Multires sculpt is displacement data, not exportable geometry. Exported live
+it either ships every subdivided face — a level-8 sculpt on a 30-face cage is
+~2 million faces — or drops the sculpt entirely, depending on
+`use_mesh_modifiers`. Neither is intended. Bake to a normal map, export the
+base cage.
+
+```python
+import bpy
+
+obj = bpy.data.objects['GEO-target']
+bpy.context.view_layer.objects.active = obj
+
+# Requires UV0 on the base cage, and a material whose ACTIVE node is an Image
+# Texture holding a Non-Color image.
+bake = bpy.context.scene.render.bake
+bake.use_multires = True      # Blender 4.x and earlier: scene.render.use_bake_multires
+bake.type = 'NORMALS'
+bake.margin = 16
+bpy.ops.object.bake_image()
+
+multires = next(m for m in obj.modifiers if m.type == 'MULTIRES')
+multires.levels = 0           # export the cage; sculpt data stays in the .blend
+
+bpy.data.images['N_target'].save()   # embed_textures can only embed a file that exists
+print(f"baked:{obj.name} sculpt_levels:{multires.total_levels}")
+```
+
+Two failure modes, both of which mislead:
+
+- **Multires must be last in the modifier stack.** Anything after it fails the
+  bake with `Multires data baking requires multi-resolution object`, which does
+  not describe the actual problem.
+- **The modifier's viewport `levels` decides what exports**, not
+  `total_levels`: `use_mesh_modifiers` evaluates at the viewport level, so a
+  mesh showing level 8 exports level 8 however the bake went.
+
 ## Polycount targets per platform
 
 | Platform | Target | Notes |
@@ -239,6 +321,10 @@ Always verify after export. Use `Bash` tool: `ls -la /tmp/output.glb`.
 | GLB > 15 MB | Apply Decimate (Recipe 2); reduce textures to 1024×1024 |
 | Bone count exceeded | Limit weights to 4 per vertex; reduce bone count |
 | Animation didn't export | glTF: `export_animations=True`; FBX: `bake_anim=True` |
+| Unreal: prop imports with no collision | Add a `UCX_<MeshName>_01` object to the same FBX (Recipe 9) |
+| Unreal: collision is wrong but nothing warned | The `UCX_` hull is concave — check convexity (Recipe 9) |
+| FBX is millions of faces, or the sculpt is missing | Multires exported live — bake it and set viewport level 0 (Recipe 10) |
+| Unreal: "No smoothing group information was found" | `mesh_smooth_type='FACE'`; Blender's default is `'OFF'` |
 
 ## When to load `references/overview.md`
 

--- a/plugin/skills/blender-export/evals/evals.json
+++ b/plugin/skills/blender-export/evals/evals.json
@@ -9,6 +9,9 @@
   { "query": "Make the model under 10 MB GLB", "should_trigger": true },
   { "query": "Export with Y-up axis orientation for Unreal", "should_trigger": true },
   { "query": "Export the animated rig as FBX with bake_anim", "should_trigger": true },
+  { "query": "Add UCX collision hulls to this mesh for Unreal", "should_trigger": true },
+  { "query": "Bake the multires sculpt to a normal map and export the low poly", "should_trigger": true },
+  { "query": "Why does Unreal say no smoothing group information was found?", "should_trigger": true },
 
   { "query": "Add a beveled cube", "should_trigger": false, "rationale": "modeling" },
   { "query": "Apply gold material", "should_trigger": false, "rationale": "materials" },
@@ -19,5 +22,7 @@
   { "query": "What's the max polycount for mobile?", "should_trigger": false, "rationale": "knowledge" },
   { "query": "Compare glTF vs FBX advantages", "should_trigger": false, "rationale": "knowledge/comparison" },
   { "query": "How do I write a custom exporter addon?", "should_trigger": false, "rationale": "addon development" },
-  { "query": "Convert FBX to glTF without using Blender", "should_trigger": false, "rationale": "external pipeline" }
+  { "query": "Convert FBX to glTF without using Blender", "should_trigger": false, "rationale": "external pipeline" },
+  { "query": "Sculpt a face into this surface", "should_trigger": false, "rationale": "sculpting, not export" },
+  { "query": "Is this hull convex?", "should_trigger": false, "rationale": "geometry query, no export intent" }
 ]


### PR DESCRIPTION
Two additions to `blender-export`, both for failures that are silent rather than loud.

## What this adds

**Recipe 9 — Collision meshes for Unreal.** The skill has no mention of `UCX_` today, so a prop exported by the existing FBX recipe imports into Unreal with no collision at all. Adds the `UCX_`/`UBX_`/`USP_`/`UCP_` naming convention, the requirement that colliders travel in the same file as their mesh, and a convexity check — because Unreal accepts a **concave** `UCX_` hull silently: no warning, no import error, wrong collision in engine.

**Recipe 10 — Multires.** A sculpt is displacement data, not exportable geometry. With `use_mesh_modifiers=True` in the existing FBX recipe, a live Multires ships every subdivided face — a level-8 sculpt on a 30-face cage is ~2 million faces. The recipe bakes to a normal map and exports the base cage, and records the two failure modes that actively mislead:

- Multires must be **last in the modifier stack**, or the bake fails with `Multires data baking requires multi-resolution object`, which does not describe the actual problem. I hit this with a stray Smooth modifier.
- The modifier's **viewport `levels`**, not `total_levels`, is what `use_mesh_modifiers` evaluates. A mesh showing level 8 exports level 8 no matter how the bake went.

Plus four pitfalls-table rows, five `evals.json` entries covering the new trigger / no-trigger boundaries, and a CHANGELOG entry.

## Honesty / limits

- **Verified on Blender 5.2.1 LTS only.** Every snippet was executed against a running Blender, not written from memory.
- **Nothing here was confirmed inside Unreal.** The collision-naming and smoothing-group claims are conventions plus Blender-side behaviour; I had no engine available to import into. Worth treating as unvalidated on the engine side until someone does.
- I could not check the 4.x spelling of `scene.render.use_bake_multires` on a 4.x install; in 5.2 it is `scene.render.bake.use_multires`, and the note reflects that.

## One question, not a change

Recipe 3 sets `bake_space_transform=True` with the comment *"critical: applies rotation to mesh"*. My own tooling sets it `False`, and a round-trip test on 5.2.1 (export → re-import) returned exact dimensions, zero rotation and unit scale with `False`. I did **not** touch your setting, because I can't test the engine-side result and you may have a reason I don't know. Flagging it in case it's worth a look.

## CHANGELOG

Filed under `## [Unreleased]` rather than a version number, since I can't know which release this lands in — happy to move it under a specific version if you'd prefer.

## Scope note

This came out of a Blender→Unreal→Quest pipeline, but everything project-specific — mobile budgets, texture-prefix conventions, a project's lighting decisions — was deliberately left out, per the sanitization principle in your 1.3.0 notes. Only the generic, reproducible parts are here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FQPvmGakiTBWrFknMeh3u